### PR TITLE
feat: modal 컴포넌트 구현(#20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "oz-14-main-fe-03",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/vite": "^4.1.18",
@@ -1697,6 +1698,60 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.1.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -1,0 +1,15 @@
+import { Dialog } from '@/components/ui/dialog';
+
+type ModalProps = {
+  children: React.ReactNode;
+  isOpen?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+};
+
+export default function Modal({ children, isOpen, onOpenChange }: ModalProps) {
+  return (
+    <Dialog onOpenChange={onOpenChange} open={isOpen}>
+      {children}
+    </Dialog>
+  );
+}

--- a/src/components/common/modal/ModalContent.tsx
+++ b/src/components/common/modal/ModalContent.tsx
@@ -1,0 +1,18 @@
+import { DialogContent } from '@/components/ui/dialog';
+import { cn } from '@/utils';
+
+type ModalContentProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function ModalContent({
+  children,
+  className,
+}: ModalContentProps) {
+  return (
+    <DialogContent className={cn('max-w-lg rounded-lg p-6', className)}>
+      {children}
+    </DialogContent>
+  );
+}

--- a/src/components/common/modal/ModalDescription.tsx
+++ b/src/components/common/modal/ModalDescription.tsx
@@ -1,0 +1,13 @@
+import { DialogDescription } from '@/components/ui/dialog';
+
+type ModalDescriptionProps = {
+  children: React.ReactNode;
+};
+
+export default function ModalDescription({ children }: ModalDescriptionProps) {
+  return (
+    <DialogDescription className="text-sm text-gray-500">
+      {children}
+    </DialogDescription>
+  );
+}

--- a/src/components/common/modal/ModalFooter.tsx
+++ b/src/components/common/modal/ModalFooter.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/utils';
+
+type ModalFooterProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function ModalFooter({ children, className }: ModalFooterProps) {
+  return (
+    <div className={cn('mt-6 flex justify-end gap-2', className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/modal/ModalHeader.tsx
+++ b/src/components/common/modal/ModalHeader.tsx
@@ -1,0 +1,10 @@
+import { cn } from '@/utils';
+
+type ModalHeaderProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function ModalHeader({ children, className }: ModalHeaderProps) {
+  return <div className={cn('mb-4 space-y-1', className)}>{children}</div>;
+}

--- a/src/components/common/modal/ModalTitle.tsx
+++ b/src/components/common/modal/ModalTitle.tsx
@@ -1,0 +1,11 @@
+import { DialogTitle } from '@/components/ui/dialog';
+
+type ModalTitleProps = {
+  children: React.ReactNode;
+};
+
+export default function ModalTitle({ children }: ModalTitleProps) {
+  return (
+    <DialogTitle className="text-lg font-semibold">{children}</DialogTitle>
+  );
+}

--- a/src/components/common/modal/ModalTrigger.tsx
+++ b/src/components/common/modal/ModalTrigger.tsx
@@ -1,0 +1,9 @@
+import { DialogTrigger } from '@/components/ui/dialog';
+
+type ModalTriggerProps = {
+  children: React.ReactNode;
+};
+
+export default function ModalTrigger({ children }: ModalTriggerProps) {
+  return <DialogTrigger asChild>{children}</DialogTrigger>;
+}

--- a/src/components/common/modal/index.ts
+++ b/src/components/common/modal/index.ts
@@ -1,0 +1,7 @@
+export { default as Modal } from './Modal';
+export { default as ModalContent } from './ModalContent';
+export { default as ModalDescription } from './ModalDescription';
+export { default as ModalFooter } from './ModalFooter';
+export { default as ModalHeader } from './ModalHeader';
+export { default as ModalTitle } from './ModalTitle';
+export { default as ModalTrigger } from './ModalTrigger';

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/utils/index';
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogContent({
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        className={cn(
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className,
+        )}
+        data-slot="dialog-content"
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            data-slot="dialog-close"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn('text-sm text-muted-foreground', className)}
+      data-slot="dialog-description"
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      data-slot="dialog-footer"
+      {...props}
+    />
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      data-slot="dialog-header"
+      {...props}
+    />
+  );
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className,
+      )}
+      data-slot="dialog-overlay"
+      {...props}
+    />
+  );
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn('text-lg leading-none font-semibold', className)}
+      data-slot="dialog-title"
+      {...props}
+    />
+  );
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};


### PR DESCRIPTION
## 📌 작업 내용
- shadcn dialog를 기반으로 공통 modal 컴포넌트 구현
- modal을 root / trigger / content / header / footer / title / description 역할로 분리
- ui dialog 컴포넌트를 직접 사용하지 않고 common 레이어에서 래핑하여 사용하도록 구조화

## 🧩 설계 의도
- shadcn에서 생성된 ui 컴포넌트는 primitive 레벨로 유지하고,
  프로젝트 공통 UI 규칙은 common modal 컴포넌트에서 관리하도록 분리했습니다.
- 이를 통해 접근성, 일관성, 유지보수성을 확보하고
  feature/pages에서는 공통 modal 컴포넌트만 사용하도록 유도했습니다.

## 🔗 관련 이슈
- closes #20 

## 🧪 테스트
- 테스트용 페이지에서 modal을 직접 사용하여
  trigger 클릭, overlay 클릭, ESC 키 동작을 확인했습니다.
- 포커스 이동 및 복귀 등 기본 접근성 동작이 정상임을 확인했습니다.

## ✅ 체크리스트
- [x] 팀 코드 컨벤션 준수
- [x] shadcn ui 원본 파일 미수정
- [x] 공통 컴포넌트 레이어로 래핑하여 사용
- [x] lint / build 오류 없음
