### PR TITLE
feat: 로그인 후 헤더 컴포넌트 UI 구현(#41)

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,11 @@
-import { MenuIcon } from 'lucide-react';
+import {
+  BellIcon,
+  ChevronDownIcon,
+  MenuIcon,
+  SearchIcon,
+  UserIcon,
+} from 'lucide-react';
+import { useState } from 'react';
 import { Link } from 'react-router';
 
 import { ROUTES_PATHS } from '@/constants';
@@ -10,6 +17,12 @@ type HeaderProps = {
 };
 
 export function Header({ onMenuClick }: HeaderProps) {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  const handleLogin = () => {
+    setIsLoggedIn(true);
+  };
+
   return (
     <header className="sticky top-0 z-60 flex items-center justify-between border-b border-[#E5E7EB] bg-[#070913] px-6 py-3">
       <div className="flex items-center justify-start gap-3">
@@ -28,9 +41,43 @@ export function Header({ onMenuClick }: HeaderProps) {
           Near 0.5
         </Link>
       </div>
-      <Button rounded="sm" size="sm" variant="lightGrey">
-        로그인
-      </Button>
+      {!isLoggedIn ? (
+        <Button
+          onClick={handleLogin}
+          rounded="sm"
+          size="sm"
+          variant="lightGrey"
+        >
+          로그인
+        </Button>
+      ) : (
+        <div className="flex items-center gap-3">
+          <Button className="text-[#ffffff]" size="icon" variant="ghost">
+            <SearchIcon size={22} />
+          </Button>
+
+          <div className="relative">
+            <Button className="text-[#ffffff]" size="icon" variant="ghost">
+              <BellIcon size={22} />
+            </Button>
+            <span className="absolute top-0 right-0 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+              3
+            </span>
+          </div>
+
+          <div className="ml-2 flex items-center gap-1">
+            <Button
+              className="h-10 w-10 rounded-full bg-purple-500 p-0 hover:bg-purple-600"
+              variant="ghost"
+            >
+              <UserIcon className="text-white" size={20} />
+            </Button>
+            <Button className="text-[#ffffff]" size="icon" variant="ghost">
+              <ChevronDownIcon size={20} />
+            </Button>
+          </div>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용

- 아이콘 3개 만듬.

## 🔗 관련 이슈

- closes #41

## 📸 스크린샷 (선택)

<img width="598" height="197" alt="image" src="https://github.com/user-attachments/assets/56267591-33b5-40c0-9d00-e8d298dc37e8" />

