### PR TITLE
feat: 스트리밍 페이지 기본 ui 구현(#47)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,17 @@ import { Route, Routes } from 'react-router';
 
 import { MainLayout } from '@/components';
 import { ROUTES_PATHS } from '@/constants';
-import { MainPage, NotFound } from '@/pages';
+import { MainPage, NotFound, StreamingPage } from '@/pages';
 
 function App() {
   const ROUTES = [
     {
       element: <MainPage />,
       path: ROUTES_PATHS.MAIN,
+    },
+    {
+      element: <StreamingPage />,
+      path: ROUTES_PATHS.STREAMING,
     },
     {
       element: <NotFound />,

--- a/src/components/common/modal/ModalTrigger.tsx
+++ b/src/components/common/modal/ModalTrigger.tsx
@@ -1,9 +1,17 @@
-import { DialogTrigger } from '@/components';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
 
 type ModalTriggerProps = {
+  asChild?: boolean;
   children: React.ReactNode;
 };
 
-export default function ModalTrigger({ children }: ModalTriggerProps) {
-  return <DialogTrigger asChild>{children}</DialogTrigger>;
+export default function ModalTrigger({
+  asChild = false,
+  children,
+}: ModalTriggerProps) {
+  return (
+    <DialogPrimitive.Trigger asChild={asChild}>
+      {children}
+    </DialogPrimitive.Trigger>
+  );
 }

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -6,5 +6,5 @@ export const ROUTES_PATHS = {
   MYPAGE: '/mypage',
   NOT_FOUND: '*',
   SIGNUP: '/signup',
-  STREAMING: '/streaming',
+  STREAMING: '/live-stream',
 };

--- a/src/features/live/components/ChatPlaceholder.tsx
+++ b/src/features/live/components/ChatPlaceholder.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@/components';
+import LoginRequiredModal from '@/features/live/components/LoginRequiredModal';
+
+export default function ChatPlaceholder() {
+  return (
+    <div className="flex h-full flex-col rounded border">
+      <div className="flex-1 p-4 text-sm text-gray-400">채팅 영역</div>
+
+      <div className="border-t p-3">
+        <LoginRequiredModal>
+          <Button className="w-full" size="default" variant="lightGrey">
+            로그인 후 채팅 가능
+          </Button>
+        </LoginRequiredModal>
+      </div>
+    </div>
+  );
+}

--- a/src/features/live/components/LoginRequiredModal.tsx
+++ b/src/features/live/components/LoginRequiredModal.tsx
@@ -1,0 +1,21 @@
+import { Modal, ModalContent, ModalTrigger } from '@/components';
+
+type LoginRequiredModalProps = {
+  children: React.ReactNode;
+};
+
+export default function LoginRequiredModal({
+  children,
+}: LoginRequiredModalProps) {
+  return (
+    <Modal>
+      <ModalTrigger asChild>{children}</ModalTrigger>
+
+      <ModalContent>
+        <p className="text-sm text-gray-600">
+          로그인 후 채팅을 이용할 수 있습니다.
+        </p>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/features/live/components/StreamHeader.tsx
+++ b/src/features/live/components/StreamHeader.tsx
@@ -1,0 +1,31 @@
+import {
+  Button,
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from '@/components';
+
+export default function StreamHeader() {
+  return (
+    <header className="flex items-center justify-between">
+      <div>
+        <h1 className="text-xl font-semibold">스트리밍 제목</h1>
+        <p className="text-sm text-gray-500">LIVE · 시청자 수</p>
+      </div>
+
+      <Dropdown>
+        <DropdownTrigger>
+          <Button size="sm" variant="transparent">
+            옵션
+          </Button>
+        </DropdownTrigger>
+
+        <DropdownContent>
+          <DropdownItem>공유</DropdownItem>
+          <DropdownItem>신고</DropdownItem>
+        </DropdownContent>
+      </Dropdown>
+    </header>
+  );
+}

--- a/src/features/live/components/StreamPlayerPlaceholder.tsx
+++ b/src/features/live/components/StreamPlayerPlaceholder.tsx
@@ -1,0 +1,7 @@
+export default function StreamPlayerPlaceholder() {
+  return (
+    <div className="flex aspect-video items-center justify-center rounded bg-black">
+      <span className="text-sm text-gray-400">스트리밍 영상 영역</span>
+    </div>
+  );
+}

--- a/src/features/live/components/index.ts
+++ b/src/features/live/components/index.ts
@@ -1,0 +1,3 @@
+export { default as ChatPlaceholder } from './ChatPlaceholder';
+export { default as StreamHeader } from './StreamHeader';
+export { default as StreamPlayerPlaceholder } from './StreamPlayerPlaceholder';

--- a/src/pages/StreamingPage.tsx
+++ b/src/pages/StreamingPage.tsx
@@ -1,0 +1,23 @@
+import {
+  ChatPlaceholder,
+  StreamHeader,
+  StreamPlayerPlaceholder,
+} from '@/features/live/components';
+
+export default function StreamingPage() {
+  return (
+    <main className="mx-auto max-w-7xl px-6 py-4">
+      <StreamHeader />
+
+      <section className="mt-4 grid grid-cols-12 gap-4">
+        <div className="col-span-8">
+          <StreamPlayerPlaceholder />
+        </div>
+
+        <div className="col-span-4">
+          <ChatPlaceholder />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
 export { default as MainPage } from './MainPage';
 export { default as NotFound } from './NotFound';
+export { default as StreamingPage } from './StreamingPage';


### PR DESCRIPTION
## 📌 작업 내용
- 스트리밍 페이지 기본 UI 레이아웃 구현
- 영상 영역 및 채팅 영역 placeholder UI 구성
- 공통 dropdown, modal 컴포넌트 사용 예시 추가

## 🔗 관련 이슈
- closes #47 

## 🧪 테스트
- 스트리밍 페이지를 라우트에 연결하여 화면 렌더링 확인
- dropdown / modal 기본 인터랙션 정상 동작 확인

## 📸 스크린샷 (선택)
<img width="1727" height="907" alt="스크린샷 2026-01-21 오전 10 12 36" src="https://github.com/user-attachments/assets/f6d40381-93ad-44b5-8d21-0162e9c4b4ea" />

## 📎 참고 사항
- 본 PR은 스트리밍 페이지의 기본 UI만 구현하며,
  실제 스트리밍(IVS) 및 채팅 로직은 이후 이슈에서 진행 예정입니다.

## ✅ 체크리스트
- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인