### PR TITLE
feat: 메인 페이지 섹션 컴포넌트 구조 구현(#36)

### DIFF
--- a/src/features/main/components/ArtistSection.tsx
+++ b/src/features/main/components/ArtistSection.tsx
@@ -1,0 +1,43 @@
+import type { ArtistSectionProps } from '@/features/main/types';
+
+import { Button } from '@/components';
+import { DUMMY_ARTISTS } from '@/features/main/mocks/mainData';
+
+export default function ArtistSection({ title }: ArtistSectionProps) {
+  return (
+    <section className="w-full px-6 py-10 md:px-10">
+      <div className="mx-auto max-w-293">
+        <header className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-white">{title}</h2>
+          <Button
+            className="h-auto px-0 text-xs font-semibold text-[#C7C9D9] hover:text-white"
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            더보기
+          </Button>
+        </header>
+
+        <div className="scrollbar-hide flex gap-4 overflow-x-auto pb-4">
+          {DUMMY_ARTISTS.map(({ id, imageUrl, name }) => (
+            <article
+              className="flex w-34.5 shrink-0 flex-col items-center justify-center"
+              key={id}
+            >
+              <div className="h-16 w-16 overflow-hidden rounded-full border-2 border-transparent transition-colors hover:border-[#DC196D]">
+                <img
+                  alt={name}
+                  className="h-full w-full object-cover"
+                  src={imageUrl}
+                />
+              </div>
+
+              <p className="mt-2 text-xs font-medium text-white">{name}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/main/components/CategorySection.tsx
+++ b/src/features/main/components/CategorySection.tsx
@@ -1,0 +1,42 @@
+import type { CategorySectionProps } from '@/features/main/types';
+
+import { Button } from '@/components';
+import { CATEGORIES } from '@/features/main/mocks/mainData';
+
+export default function CategorySection({ title }: CategorySectionProps) {
+  return (
+    <section className="w-full px-6 pb-10 md:px-10">
+      <div className="mx-auto max-w-293 space-y-3">
+        <header className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+          <Button
+            className="h-auto bg-[#1A1F2E] px-0 text-xs font-semibold text-[#C7C9D9] hover:text-white"
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            더보기
+          </Button>
+        </header>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+          {CATEGORIES.map(({ id, label }) => (
+            <Button
+              className="group w-full rounded-2xl border-2 border-[#4A5565] hover:border-[#F3F4F6] hover:bg-[#D4D4D4]"
+              key={id}
+              size="chip"
+              type="button"
+              variant="navy"
+            >
+              <div className="flex h-10 w-10 items-center justify-center">
+                <span className="text-3xl">🎤</span>
+              </div>
+              <span className="text-sm font-semibold text-white group-hover:text-black">
+                {label}
+              </span>
+            </Button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/main/components/ConcertCard.tsx
+++ b/src/features/main/components/ConcertCard.tsx
@@ -1,0 +1,46 @@
+import type { ConcertCardProps } from '@/features/main/types';
+
+import { Button } from '@/components';
+
+export default function ConcertCard({
+  dateLabel,
+  locationLabel,
+  thumbnailUrl,
+  timeLabel,
+  title,
+}: ConcertCardProps) {
+  return (
+    <article className="group flex h-90.75 flex-col overflow-hidden rounded-3xl border border-[#4A5565] bg-[#101828] transition-colors duration-200 hover:border-[#DC196D]">
+      <div className="relative h-52.5 w-full overflow-hidden">
+        <img
+          alt={title}
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          src={thumbnailUrl}
+        />
+        <div className="absolute top-4 left-4 rounded-full bg-[#E11DFF] px-5 py-1.5 text-xs leading-none font-semibold text-white">
+          {dateLabel}
+        </div>
+        <div className="absolute top-4 right-4 rounded-full bg-black/70 px-4 py-1 text-xs font-semibold text-white">
+          공개 예정
+        </div>
+        <div className="absolute right-4 bottom-3 left-4 flex items-center justify-between text-xs text-white">
+          <p>{timeLabel}</p>
+          <p className="truncate text-right">{locationLabel}</p>
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col justify-between px-4 py-3">
+        <h3 className="line-clamp-2 text-lg leading-tight font-bold text-white">
+          {title}
+        </h3>
+        <Button
+          className="mt-1 w-full justify-center gap-1 text-sm font-semibold"
+          rounded="full"
+          size="lg"
+          variant="lightGrey"
+        >
+          알림 받기
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/src/features/main/components/HeroBanner.tsx
+++ b/src/features/main/components/HeroBanner.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components';
+
+export default function HeroBanner() {
+  const data = {
+    backgroundImageUrl: '', // TODO: image 폴더 추가 후 경로 설정
+    primaryActionLabel: '알림 신청하기',
+    statusLabel: 'UPCOMING CONCERT',
+    subtitle: 'From KickFlip, To WE:Flip',
+    title: '2026 KickFlip FAN-CON',
+  };
+
+  return (
+    <section className="relative w-full overflow-hidden bg-background">
+      <div className="absolute inset-0">
+        <img
+          alt={data.title}
+          className="h-full w-full object-cover"
+          src={data.backgroundImageUrl}
+        />
+        <div className="absolute inset-0 bg-linear-to-t from-background/10 via-background/40 to-background/95" />
+      </div>
+      <div className="relative flex min-h-90 flex-col justify-end px-8 pt-16 pb-10 md:min-h-105">
+        <div className="max-w-xl space-y-4 text-left text-primary-foreground">
+          <span className="bg-navy-500/90 inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold tracking-wide text-white uppercase shadow-sm">
+            {data.statusLabel}
+          </span>
+          <div className="space-y-2">
+            <h1 className="text-3xl leading-tight font-semibold md:text-4xl lg:text-5xl">
+              {data.title}
+            </h1>
+            <p className="text-sm text-muted-foreground md:text-base">
+              {data.subtitle}
+            </p>
+          </div>
+          <div className="mt-4">
+            <Button
+              className="min-w-37.75"
+              rounded="full"
+              size="lg"
+              variant="navy"
+            >
+              {data.primaryActionLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/main/components/InterestArtistSection.tsx
+++ b/src/features/main/components/InterestArtistSection.tsx
@@ -1,0 +1,50 @@
+import type { InterestArtistSectionProps } from '@/features/main/types';
+
+import { Button } from '@/components';
+import { INTEREST_ARTISTS } from '@/features/main/mocks/mainData';
+
+export default function InterestArtistSection({
+  title,
+}: InterestArtistSectionProps) {
+  return (
+    <section className="w-full px-6 py-10 md:px-10">
+      <div className="mx-auto max-w-293 space-y-4">
+        <header className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+
+          <Button
+            className="h-auto px-0 text-xs font-semibold text-[#C7C9D9] hover:text-white"
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            더보기
+          </Button>
+        </header>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {INTEREST_ARTISTS.map(({ id, name }) => (
+            <Button
+              className="shrink-0 rounded-full border border-[#E5E7EB] px-4 text-xs font-medium text-[#E5E7EB] hover:border-white hover:bg-white hover:text-black"
+              key={id}
+              size="sm"
+              type="button"
+              variant="navy"
+            >
+              {name}
+            </Button>
+          ))}
+
+          <Button
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-[#E5E7EB] bg-[#F3F4F6] text-xs font-semibold text-black"
+            size="icon"
+            type="button"
+            variant="navy"
+          >
+            →
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/main/components/OngoingLiveCard.tsx
+++ b/src/features/main/components/OngoingLiveCard.tsx
@@ -1,0 +1,37 @@
+import type { OngoingLiveCardProps } from '@/features/main/types';
+
+export default function OngoingLiveCard({
+  durationLabel,
+  isLive = true,
+  thumbnailUrl,
+  title,
+}: OngoingLiveCardProps) {
+  return (
+    <article className="group flex h-66.5 w-full flex-col overflow-hidden rounded-3xl border border-[#4A5565] bg-[#101828] transition-colors duration-200 hover:border-[#DC196D]">
+      <div className="relative h-52.5 w-full overflow-hidden">
+        <img
+          alt={title}
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          src={thumbnailUrl}
+        />
+        {isLive && (
+          <div className="absolute top-4 left-4 rounded-full bg-[#E7000B] px-4 py-1 text-xs font-bold text-white">
+            LIVE
+          </div>
+        )}
+        {durationLabel ? (
+          <div className="absolute right-4 bottom-4 rounded-full bg-black/80 px-3 py-1 text-xs font-semibold text-white">
+            {durationLabel}
+          </div>
+        ) : (
+          <div className="absolute top-4 right-4 flex h-6 w-6 items-center justify-center rounded-full bg-black/80">
+            <span className="h-2 w-3 rounded-full border border-white" />
+          </div>
+        )}
+      </div>
+      <div className="flex flex-1 items-center bg-[#101828] px-4 py-3">
+        <h3 className="line-clamp-1 text-base font-bold text-white">{title}</h3>
+      </div>
+    </article>
+  );
+}

--- a/src/features/main/components/OngoingStreamingSection.tsx
+++ b/src/features/main/components/OngoingStreamingSection.tsx
@@ -1,0 +1,34 @@
+import type { OngoingStreamingSectionProps } from '@/features/main/types';
+
+import { Button } from '@/components';
+import { DUMMY_ONGOING_LIVES } from '@/features/main/mocks/mainData';
+
+import OngoingLiveCard from './OngoingLiveCard';
+
+export default function OngoingStreamingSection({
+  title,
+}: OngoingStreamingSectionProps) {
+  return (
+    <section className="w-full px-6 py-10 md:px-10">
+      <div className="mx-auto max-w-293 space-y-6">
+        <header className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white md:text-xl">
+            {title}
+          </h2>
+          <Button
+            className="h-auto px-0 text-xs font-semibold text-[#C7C9D9] hover:text-white"
+            size="sm"
+            variant="ghost"
+          >
+            더보기
+          </Button>
+        </header>
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {DUMMY_ONGOING_LIVES.map(live => (
+            <OngoingLiveCard key={live.title} {...live} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/main/components/UpcomingStreamingSection.tsx
+++ b/src/features/main/components/UpcomingStreamingSection.tsx
@@ -1,0 +1,33 @@
+import type { UpcomingStreamingSectionProps } from '@/features/main/types';
+
+import { Button } from '@/components';
+import { DUMMY_CONCERTS } from '@/features/main/mocks/mainData';
+
+import ConcertCard from './ConcertCard';
+
+export default function UpcomingStreamingSection({
+  title,
+}: UpcomingStreamingSectionProps) {
+  return (
+    <section className="w-full px-6 py-10 md:px-10">
+      <div className="mx-auto max-w-293 space-y-6">
+        <header className="flex items-center justify-between">
+          <h2 className="text-xl font-bold text-white">{title}</h2>
+          <Button
+            className="h-auto px-0 text-xs font-semibold text-[#C7C9D9] hover:text-white"
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            더보기
+          </Button>
+        </header>
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {DUMMY_CONCERTS.map(concert => (
+            <ConcertCard key={concert.title} {...concert} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/main/components/index.ts
+++ b/src/features/main/components/index.ts
@@ -1,0 +1,8 @@
+export { default as ArtistSection } from './ArtistSection';
+export { default as CategorySection } from './CategorySection';
+export { default as ConcertCard } from './ConcertCard';
+export { default as HeroBanner } from './HeroBanner';
+export { default as InterestArtistSection } from './InterestArtistSection';
+export { default as OngoingLiveCard } from './OngoingLiveCard';
+export { default as OngoingStreamingSection } from './OngoingStreamingSection';
+export { default as UpcomingStreamingSection } from './UpcomingStreamingSection';

--- a/src/features/main/mocks/mainData.ts
+++ b/src/features/main/mocks/mainData.ts
@@ -1,0 +1,86 @@
+import type {
+  CategoryItem,
+  ConcertCardProps,
+  InterestArtistItem,
+  OngoingLiveCardProps,
+  Artist as RecommendedArtistItem,
+} from '@/features/main/types';
+
+// 추천 카테고리
+export const CATEGORIES: CategoryItem[] = [
+  { id: 'kpop', label: 'K-POP' },
+  { id: 'band', label: '밴드' },
+  { id: 'musical', label: '뮤지컬' },
+  { id: 'overseas', label: '내한 공연' },
+  { id: 'trot', label: '트로트' },
+];
+
+// 추천 아티스트
+export const DUMMY_ARTISTS: RecommendedArtistItem[] = [
+  { id: 1, imageUrl: '/images/artist-1.jpg', name: 'FIFTYFIFTY' },
+  { id: 2, imageUrl: '/images/artist-2.jpg', name: 'ILLIT' },
+  { id: 3, imageUrl: '/images/artist-3.jpg', name: 'PANG SO DAM' },
+  { id: 4, imageUrl: '/images/artist-4.jpg', name: 'Heart2Hearts' },
+];
+
+// 관심 아티스트
+export const INTEREST_ARTISTS: InterestArtistItem[] = [
+  { id: 1, name: 'VANK' },
+  { id: 2, name: 'Astro' },
+  { id: 3, name: 'YOUNG POSSE' },
+  { id: 4, name: 'HVNE' },
+  { id: 5, name: 'ENHYPEN' },
+  { id: 6, name: 'TNX' },
+  { id: 7, name: 'ILLIT' },
+  { id: 8, name: 'BTS' },
+  { id: 9, name: 'RIIZE REPUBLIC' },
+  { id: 10, name: 'StayC' },
+  { id: 11, name: '한강가' },
+];
+
+// 진행 중 콘서트 라이브
+export const DUMMY_ONGOING_LIVES: OngoingLiveCardProps[] = [
+  {
+    durationLabel: '1:20:45',
+    isLive: true,
+    thumbnailUrl: '/images/ongoing-live-1.jpg',
+    title: 'LE SSERAFIM 컴백 쇼케이스 LIVE',
+  },
+  {
+    durationLabel: '45:20',
+    isLive: true,
+    thumbnailUrl: '/images/ongoing-live-2.jpg',
+    title: '팬미팅 생중계',
+  },
+  {
+    durationLabel: '1:23:15',
+    isLive: true,
+    thumbnailUrl: '/images/ongoing-live-3.jpg',
+    title: '멤버들과 함께하는 Q&A 시간',
+  },
+];
+
+// 예정된 라이브
+export const DUMMY_CONCERTS: ConcertCardProps[] = [
+  {
+    dateLabel: '2026.09.15',
+    locationLabel: '올림픽공원 KSPO DOME',
+    thumbnailUrl: '/images/dummy-concert-1.jpg',
+    timeLabel: '오후 7:00 (KST)',
+    title: 'LE SSERAFIM 2024 WORLD TOUR',
+  },
+  {
+    dateLabel: '2026.09.08',
+    locationLabel: '온라인 생중계',
+    thumbnailUrl: '/images/dummy-concert-2.jpg',
+    timeLabel: '오후 8:00 (KST)',
+    title: 'CRAZY 앨범 쇼케이스 라이브',
+  },
+  {
+    dateLabel: '2026.09.10',
+    locationLabel: '강변 팬사인회장',
+    thumbnailUrl: '/images/dummy-concert-3.jpg',
+    timeLabel: '오후 3:00 (KST)',
+    title: '팬사인회 생중계',
+  },
+];

--- a/src/features/main/types/ArtistSection.ts
+++ b/src/features/main/types/ArtistSection.ts
@@ -1,0 +1,9 @@
+export type Artist = {
+  id: number;
+  imageUrl: string;
+  name: string;
+};
+
+export type ArtistSectionProps = {
+  title: string;
+};

--- a/src/features/main/types/CategorySection.ts
+++ b/src/features/main/types/CategorySection.ts
@@ -1,0 +1,8 @@
+export type CategoryItem = {
+  id: string;
+  label: string;
+};
+
+export type CategorySectionProps = {
+  title: string;
+};

--- a/src/features/main/types/ConcertCard.ts
+++ b/src/features/main/types/ConcertCard.ts
@@ -1,0 +1,7 @@
+export type ConcertCardProps = {
+  dateLabel: string;
+  locationLabel: string;
+  thumbnailUrl: string;
+  timeLabel: string;
+  title: string;
+};

--- a/src/features/main/types/InterestArtistSection.ts
+++ b/src/features/main/types/InterestArtistSection.ts
@@ -1,0 +1,8 @@
+export type InterestArtistItem = {
+  id: number;
+  name: string;
+};
+
+export type InterestArtistSectionProps = {
+  title: string;
+};

--- a/src/features/main/types/OngoingLiveCard.ts
+++ b/src/features/main/types/OngoingLiveCard.ts
@@ -1,0 +1,6 @@
+export type OngoingLiveCardProps = {
+  durationLabel: string;
+  isLive?: boolean;
+  thumbnailUrl: string;
+  title: string;
+};

--- a/src/features/main/types/OngoingStreamingSection.ts
+++ b/src/features/main/types/OngoingStreamingSection.ts
@@ -1,0 +1,3 @@
+export type OngoingStreamingSectionProps = {
+  title: string;
+};

--- a/src/features/main/types/UpcomingStreamingSection.ts
+++ b/src/features/main/types/UpcomingStreamingSection.ts
@@ -1,0 +1,3 @@
+export type UpcomingStreamingSectionProps = {
+  title: string;
+};

--- a/src/features/main/types/index.ts
+++ b/src/features/main/types/index.ts
@@ -1,0 +1,7 @@
+export * from './ArtistSection';
+export * from './CategorySection';
+export * from './ConcertCard';
+export * from './InterestArtistSection';
+export * from './OngoingLiveCard';
+export * from './OngoingStreamingSection';
+export * from './UpcomingStreamingSection';

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,3 +1,21 @@
+import {
+  ArtistSection,
+  CategorySection,
+  HeroBanner,
+  InterestArtistSection,
+  OngoingStreamingSection,
+  UpcomingStreamingSection,
+} from '@/features/main/components';
+
 export default function MainPage() {
-  return <div>메인페이지</div>;
+  return (
+    <div className="min-h-screen bg-[#1A1F2E]">
+      <HeroBanner />
+      <UpcomingStreamingSection title="예정된 콘서트" />
+      <OngoingStreamingSection title="진행중인 라이브 콘서트" />
+      <InterestArtistSection title="관심 아티스트" />
+      <CategorySection title="추천 카테고리" />
+      <ArtistSection title="추천 아티스트" />
+    </div>
+  );
 }


### PR DESCRIPTION
## 📌 작업 내용
- 메인 Hero 배너 섹션 레이아웃 정리
- 예정된 콘서트/진행중 라이브 스트리밍 카드 UI 피그마 스펙 맞춤
- 관심 아티스트/추천 아티스트/추천카테고리 섹션
- 카드 높이, 내부 패딩, 제목–버튼 간 간격 조정
- 섹션 헤더 "더보기" 버튼 추가 및 스타일 적용
- 공통 Button 컴포넌트 사용 범위 확장 (알림 받기 / 더보기 등)


## 🖼️ 스크린샷 
<img width="769" height="434" alt="스크린샷 2026-01-21 오후 4 04 17" src="https://github.com/user-attachments/assets/e4c54761-daed-42aa-a6fe-070b0bea55bc" />
<img width="1499" height="855" alt="스크린샷 2026-01-21 오후 4 04 03" src="https://github.com/user-attachments/assets/2366a20e-04ea-4d31-b127-d17bff414882" />
<img width="1289" height="692" alt="스크린샷 2026-01-22 오후 11 59 24" src="https://github.com/user-attachments/assets/0b470535-ce47-4da6-bd7f-3708a72727b3" />


## ✅ 체크리스트
- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
- [x] 피그마와 카드 레이아웃/간격 수동 확인


## 추가사항
- rem 사용 이슈도 반영 완료
고정 px가 꼭 필요한 값은 팀과 상의해서 spacing 확장으로 추가할께요
놓치는 부분 있다면 실수로 봐주시고 정정 이어가도록 하겠습니다

- 타입/목데이터 구조 정리
- 카드 컴포넌트 독립 파일 분리
- 컴포넌트/타입 배럴구조 도입
- 섹션별 Props 다이어트 및 export default function 컨벤션 전면 적용
- mock 데이터 파일명 정규화

