### PR TITLE
refactor: tailwind 관련 lint 설정 변경(#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["bradlc.vscode-tailwindcss"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "tailwindCSS.lint.invalidApply": "error",
+  "tailwindCSS.lint.recommendedVariantOrder": "warning"
+}


### PR DESCRIPTION
## 📌 작업 내용

- tailwind 관련 lint 설정 변경

## 🔗 관련 이슈

- closes #54

## 전달사항(필독)

- 멘토님이 말씀하신 것 처럼 수정해달라고 계속해도 사용하는 팀원도 컨벤션을 추가하지 않는 팀장의 잘못도 있다고 하신걸 듣고 제 책임도 있다는걸 깨달았습니다. 핑계가 아니라 상황 설명차원에서 말씀드리지만 tailwind에서 px값을 사용했을때 노란줄이 뜨는걸 어제 처음 알았습니다. 미처 확인하지 못한 부분 사과드립니다. 컨벤션에 맞게 lint에서 tailwind를 설정하려 했지만 prettier설정과 충돌이 나서 다른방식을 찾다가 여기까지 오게 되었습니다. 해당 방식을 따라 세팅해주시기 바랍니다

<img width="897" height="570" alt="image" src="https://github.com/user-attachments/assets/7f77a1f7-a40a-4303-b691-827d98ce9032" />
1. 확장 프로그램에 들어가 Tailwind CSS IntelliSense를 받아주세요.


2. 컨벤션 문서를 확인 해주세요(px 사용에 대한 컨벤션을 적어 놓도록 하겠습니다)