### PR TITLE
feat: 스트리밍 페이지 채팅 및 로그인 모달 연동(#47)

### DIFF
--- a/src/features/live/components/ChatPanel.tsx
+++ b/src/features/live/components/ChatPanel.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+
+import { Button } from '@/components';
+import { useLiveChat } from '@/features/live/hooks/useLiveChat';
+
+type ChatPanelProps = {
+  isAuthenticated: boolean;
+  onRequireLogin: () => void;
+  roomId: string;
+  streamingId: number;
+};
+
+export default function ChatPanel({
+  isAuthenticated,
+  onRequireLogin,
+  roomId,
+  streamingId,
+}: ChatPanelProps) {
+  const { isConnected, messages, sendMessage } = useLiveChat({
+    roomId,
+    streamingId,
+  });
+
+  const [input, setInput] = useState('');
+
+  const handleSendClick = () => {
+    if (!isAuthenticated) {
+      onRequireLogin();
+      return;
+    }
+
+    if (!input.trim()) {
+      return;
+    }
+
+    sendMessage(input);
+    setInput('');
+  };
+
+  return (
+    <section className="flex h-full flex-col rounded-xl border border-gray-200 bg-white">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b px-4 py-3">
+        <span className="text-sm font-semibold text-gray-900">실시간 채팅</span>
+
+        <span
+          className={`text-xs ${
+            isConnected ? 'text-green-600' : 'text-red-500'
+          }`}
+        >
+          {isConnected ? '연결됨' : '연결 끊김'}
+        </span>
+      </header>
+
+      {/* Messages */}
+      <ul className="flex-1 space-y-3 overflow-y-auto px-4 py-3">
+        {messages.map(message => {
+          const isSystem = message.kind === 'system';
+
+          return (
+            <li
+              className="flex flex-col gap-1"
+              key={`${message.ts}-${message.userId}`}
+            >
+              <span className="text-xs text-gray-400">
+                {isSystem ? 'SYSTEM' : `USER ${message.userId}`}
+              </span>
+
+              <div
+                className={`max-w-[90%] rounded-lg px-3 py-2 text-sm ${
+                  isSystem
+                    ? 'bg-gray-100 text-gray-600'
+                    : 'bg-violet-50 text-gray-900'
+                }`}
+              >
+                {message.text}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Input */}
+      <div className="shrink-0 border-t px-3 py-2">
+        <div className="flex items-center gap-2">
+          <input
+            className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none disabled:bg-gray-100 disabled:text-gray-400"
+            disabled={!isAuthenticated}
+            onChange={event => setInput(event.target.value)}
+            onClick={() => {
+              if (!isAuthenticated) {
+                onRequireLogin();
+              }
+            }}
+            placeholder={
+              isAuthenticated
+                ? '메시지를 입력하세요'
+                : '로그인 후 채팅에 참여할 수 있어요'
+            }
+            value={input}
+          />
+
+          <Button
+            disabled={!isAuthenticated}
+            onClick={handleSendClick}
+            size="sm"
+            variant="white"
+          >
+            전송
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/live/components/ChatPlaceholder.tsx
+++ b/src/features/live/components/ChatPlaceholder.tsx
@@ -1,18 +1,14 @@
 import { Button } from '@/components';
-import LoginRequiredModal from '@/features/live/components/LoginRequiredModal';
 
 export default function ChatPlaceholder() {
   return (
     <div className="flex h-full flex-col rounded border">
       <div className="flex-1 p-4 text-sm text-gray-400">채팅 영역</div>
 
-      <div className="border-t p-3">
-        <LoginRequiredModal>
-          <Button className="w-full" size="default" variant="lightGrey">
-            로그인 후 채팅 가능
-          </Button>
-        </LoginRequiredModal>
-      </div>
+      <div className="border-t p-3" />
+      <Button className="w-full" size="default" variant="lightGrey">
+        로그인 후 채팅 가능
+      </Button>
     </div>
   );
 }

--- a/src/features/live/components/LoginRequiredModal.tsx
+++ b/src/features/live/components/LoginRequiredModal.tsx
@@ -1,21 +1,45 @@
-import { Modal, ModalContent, ModalTrigger } from '@/components';
+import { Button } from '@/components';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components';
 
 type LoginRequiredModalProps = {
-  children: React.ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm?: () => void;
 };
 
 export default function LoginRequiredModal({
-  children,
+  isOpen,
+  onClose,
+  onConfirm,
 }: LoginRequiredModalProps) {
   return (
-    <Modal>
-      <ModalTrigger asChild>{children}</ModalTrigger>
+    <Dialog onOpenChange={onClose} open={isOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>로그인이 필요합니다</DialogTitle>
+          <DialogDescription>
+            로그인 후 채팅에 참여할 수 있습니다.
+          </DialogDescription>
+        </DialogHeader>
 
-      <ModalContent>
-        <p className="text-sm text-gray-600">
-          로그인 후 채팅을 이용할 수 있습니다.
-        </p>
-      </ModalContent>
-    </Modal>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button onClick={onClose} size="sm" variant="white">
+            닫기
+          </Button>
+
+          {onConfirm && (
+            <Button onClick={onConfirm} size="sm">
+              로그인
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/live/hooks/useLiveChat.ts
+++ b/src/features/live/hooks/useLiveChat.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type {
+  ChatMessage,
+  ClientMessageEvent,
+  MessageEvent,
+  RecentEvent,
+  ServerEvent,
+  SystemEvent,
+} from '@/features/live/types/chat';
+
+type UseLiveChatParams = {
+  roomId: string;
+  streamingId: number;
+};
+
+export const useLiveChat = ({ roomId, streamingId }: UseLiveChatParams) => {
+  const socketRef = useRef<null | WebSocket>(null);
+
+  const [isConnected, setIsConnected] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  useEffect(() => {
+    const socket = new WebSocket(
+      `wss://api.near05.com/v1/streamings/${streamingId}/chat`,
+    );
+
+    socketRef.current = socket;
+
+    socket.onopen = () => {
+      setIsConnected(true);
+    };
+
+    socket.onmessage = event => {
+      const parsed: ServerEvent = JSON.parse(event.data);
+
+      if (parsed.type === 'recent') {
+        handleRecentEvent(parsed);
+        return;
+      }
+
+      if (parsed.type === 'message') {
+        handleMessageEvent(parsed);
+        return;
+      }
+
+      if (parsed.type === 'system') {
+        handleSystemEvent(parsed);
+      }
+    };
+
+    socket.onclose = () => {
+      setIsConnected(false);
+    };
+
+    socket.onerror = () => {
+      setIsConnected(false);
+    };
+
+    return () => {
+      socket.close();
+    };
+  }, [roomId, streamingId]);
+
+  const handleRecentEvent = (event: RecentEvent) => {
+    const mappedMessages = event.items.map(mapServerEventToChatMessage);
+
+    setMessages(mappedMessages);
+  };
+
+  const handleMessageEvent = (event: MessageEvent) => {
+    setMessages(prev => [...prev, mapServerEventToChatMessage(event)]);
+  };
+
+  const handleSystemEvent = (event: SystemEvent) => {
+    setMessages(prev => [...prev, mapServerEventToChatMessage(event)]);
+  };
+
+  const sendMessage = (text: string) => {
+    if (!socketRef.current || socketRef.current.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const payload: ClientMessageEvent = {
+      text,
+      type: 'message',
+    };
+
+    socketRef.current.send(JSON.stringify(payload));
+  };
+
+  return {
+    isConnected,
+    messages,
+    sendMessage,
+  };
+};
+
+const mapServerEventToChatMessage = (
+  event: MessageEvent | SystemEvent,
+): ChatMessage => ({
+  kind: event.type,
+  messageId: event.message_id,
+  roomId: event.room_id,
+  text: event.text,
+  ts: event.ts,
+  userId: event.user_id,
+});

--- a/src/features/live/types/chat.ts
+++ b/src/features/live/types/chat.ts
@@ -1,0 +1,47 @@
+export type ChatMessage = {
+  kind: ChatMessageKind;
+  messageId: null | string;
+  roomId: string;
+  text: string;
+  ts: string;
+  userId: string;
+};
+
+// 채팅 메세지 타입
+export type ChatMessageKind = 'message' | 'system';
+
+// 클라이언트 -> 서버 : 메세지 전송 이벤트
+export type ClientMessageEvent = {
+  text: string;
+  type: 'message';
+};
+
+// 서버 -> 클라이언트 : message 이벤트
+export type MessageEvent = {
+  message_id: string;
+  room_id: string;
+  text: string;
+  ts: string;
+  type: 'message';
+  user_id: string;
+};
+
+//서버 -> 클라이언트 : recent 이벤트
+export type RecentEvent = {
+  items: Array<MessageEvent | SystemEvent>;
+  room_id: string;
+  type: 'recent';
+};
+
+// 서버 -> 클라이언트 전체 이벤트 유니온
+export type ServerEvent = MessageEvent | RecentEvent | SystemEvent;
+
+// 서버 -> 클라이언트 : system 이벤트
+export type SystemEvent = {
+  message_id: null;
+  room_id: string;
+  text: string;
+  ts: string;
+  type: 'system';
+  user_id: string;
+};

--- a/src/pages/StreamingPage.tsx
+++ b/src/pages/StreamingPage.tsx
@@ -1,10 +1,32 @@
+import { useState } from 'react';
+
 import {
-  ChatPlaceholder,
   StreamHeader,
   StreamPlayerPlaceholder,
 } from '@/features/live/components';
+import ChatPanel from '@/features/live/components/ChatPanel';
+import LoginRequiredModal from '@/features/live/components/LoginRequiredModal';
 
 export default function StreamingPage() {
+  //임시 로그인 상태 (나중에 Auth 붙으면 여기만 교체)
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+
+  const handleRequireLogin = () => {
+    setIsLoginModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsLoginModalOpen(false);
+  };
+
+  // 임시 로그인 처리 (실제 로그인 연동 전까지는 버튼 or 테스트용)
+  const handleMockLogin = () => {
+    setIsAuthenticated(true);
+    setIsLoginModalOpen(false);
+  };
+
   return (
     <main className="mx-auto max-w-7xl px-6 py-4">
       <StreamHeader />
@@ -15,9 +37,20 @@ export default function StreamingPage() {
         </div>
 
         <div className="col-span-4">
-          <ChatPlaceholder />
+          <ChatPanel
+            isAuthenticated={isAuthenticated}
+            onRequireLogin={handleRequireLogin}
+            roomId="123"
+            streamingId={1}
+          />
         </div>
       </section>
+
+      <LoginRequiredModal
+        isOpen={isLoginModalOpen}
+        onClose={handleCloseModal}
+        onConfirm={handleMockLogin} // 임시 로그인 액션
+      />
     </main>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용

- 스트리밍 페이지 기본 레이아웃 구성
- 실시간 채팅 패널 UI 구현
- WebSocket 기반 채팅 훅(useLiveChat) 연동
- 로그인 상태에 따른 채팅 접근 제어 로직 추가
- 로그인 필요 시 로그인 모달 분리 및 노출 처리
- Auth 연동 전까지 사용할 임시 로그인 플로우 구현

## 🔗 관련 이슈

- closes #47

## 📸 스크린샷 (선택)
<img width="1728" height="904" alt="스크린샷 2026-01-22 오후 8 23 12" src="https://github.com/user-attachments/assets/bb527f6f-aee8-48da-882a-95fb843eddf0" />


> 스트리밍 페이지 채팅 영역 및 로그인 모달 UI

## ✅ 체크리스트

- [x] 코드 컨벤션 준수
- [x] lint 에러 없음
- [x] 빌드 정상 동작 확인
