### PR TITLE
feat: 헤더 알림(Notification) 기능 구현(#91)

### DIFF
--- a/src/components/header/NotificationDropdown.tsx
+++ b/src/components/header/NotificationDropdown.tsx
@@ -1,0 +1,90 @@
+import { BellIcon } from 'lucide-react';
+import { useNavigate } from 'react-router';
+
+import {
+  Button,
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from '@/components';
+import {
+  useDeleteNotificationMutation,
+  useNotificationsQuery,
+} from '@/features/notification/hooks';
+import { cn } from '@/utils';
+
+import { notificationWrapperVariants } from './header.styles';
+
+export default function NotificationDropdown() {
+  const navigate = useNavigate();
+
+  const {
+    data: notifications = [],
+    isError,
+    isLoading,
+  } = useNotificationsQuery();
+
+  const { mutate: deleteNotification } = useDeleteNotificationMutation();
+
+  const unreadCount = notifications.length;
+
+  return (
+    <Dropdown>
+      <DropdownTrigger>
+        <div className={cn(notificationWrapperVariants())}>
+          <Button size="icon" variant="ghost">
+            <BellIcon />
+          </Button>
+
+          {unreadCount > 0 && (
+            <span className="absolute top-0 right-0 flex h-5 w-5 items-center justify-center rounded-full bg-[#E7000B] text-xs font-bold text-white">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+      </DropdownTrigger>
+
+      <DropdownContent align="end" className="w-80">
+        {isLoading && (
+          <div className="px-3 py-4 text-sm text-gray-500">
+            알림을 불러오는 중입니다.
+          </div>
+        )}
+
+        {isError && (
+          <div className="px-3 py-4 text-sm text-red-500">
+            알림을 불러오지 못했습니다.
+          </div>
+        )}
+
+        {!isLoading && !isError && unreadCount === 0 && (
+          <div className="px-3 py-4 text-sm text-gray-500">
+            새로운 알림이 없습니다.
+          </div>
+        )}
+
+        {!isLoading &&
+          !isError &&
+          notifications.map(notification => (
+            <DropdownItem
+              key={notification.id}
+              onSelect={() => {
+                navigate(`/streamings/${notification.sessionId}`);
+                deleteNotification(notification.id);
+              }}
+            >
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium">
+                  {notification.title}
+                </span>
+                <span className="text-xs text-gray-500">
+                  {notification.message}
+                </span>
+              </div>
+            </DropdownItem>
+          ))}
+      </DropdownContent>
+    </Dropdown>
+  );
+}

--- a/src/components/header/UserMenuDropdown.tsx
+++ b/src/components/header/UserMenuDropdown.tsx
@@ -1,0 +1,44 @@
+import { ChevronDownIcon, UserIcon } from 'lucide-react';
+import { useNavigate } from 'react-router';
+
+import {
+  Button,
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from '@/components';
+import { ROUTES_PATHS } from '@/constants';
+import { useAuthStore } from '@/features/auth';
+
+export default function UserMenuDropdown() {
+  const logout = useAuthStore(state => state.logout);
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate(ROUTES_PATHS.MAIN);
+  };
+
+  return (
+    <Dropdown>
+      <DropdownTrigger>
+        <Button
+          className="flex gap-1"
+          rounded="full"
+          size="default"
+          variant="pink"
+        >
+          <UserIcon />
+          <ChevronDownIcon />
+        </Button>
+      </DropdownTrigger>
+
+      <DropdownContent align="end">
+        <DropdownItem isDanger onSelect={handleLogout}>
+          로그아웃
+        </DropdownItem>
+      </DropdownContent>
+    </Dropdown>
+  );
+}

--- a/src/components/header/header.styles.ts
+++ b/src/components/header/header.styles.ts
@@ -1,0 +1,23 @@
+import { cva } from 'class-variance-authority';
+
+export const headerRootVariants = cva(
+  'fixed top-0 right-0 left-0 z-50 flex items-center justify-between border-b px-6',
+  {
+    defaultVariants: {
+      height: 'default',
+      tone: 'dark',
+    },
+    variants: {
+      height: {
+        default: 'h-15',
+      },
+      tone: {
+        dark: 'bg-[#070913] border-[#E5E7EB]',
+      },
+    },
+  },
+);
+
+export const headerGroupVariants = cva('flex items-center gap-3');
+
+export const notificationWrapperVariants = cva('relative');

--- a/src/components/header/index.ts
+++ b/src/components/header/index.ts
@@ -1,0 +1,3 @@
+export * from './header.styles';
+export * from './NotificationDropdown';
+export * from './UserMenuDropdown';

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,16 +1,16 @@
-import {
-  BellIcon,
-  ChevronDownIcon,
-  MenuIcon,
-  SearchIcon,
-  UserIcon,
-} from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { MenuIcon, SearchIcon } from 'lucide-react';
 import { Link, useNavigate } from 'react-router';
 
 import { Button } from '@/components';
+import {
+  headerGroupVariants,
+  headerRootVariants,
+} from '@/components/header/header.styles';
+import NotificationDropdown from '@/components/header/NotificationDropdown';
+import UserMenuDropdown from '@/components/header/UserMenuDropdown';
 import { ROUTES_PATHS } from '@/constants';
 import { useAuthStore } from '@/features/auth';
+import { cn } from '@/utils';
 
 type HeaderProps = {
   onMenuClick: () => void;
@@ -18,66 +18,23 @@ type HeaderProps = {
 
 export function Header({ onMenuClick }: HeaderProps) {
   const isLoggedIn = useAuthStore(state => Boolean(state.accessToken));
-  const logout = useAuthStore(state => state.logout);
   const navigate = useNavigate();
 
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsDropdownOpen(false);
-      }
-    };
-
-    if (isDropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isDropdownOpen]);
-
-  const handleLogin = () => {
-    navigate(ROUTES_PATHS.LOGIN);
-  };
-
-  const handleLogout = async () => {
-    setIsDropdownOpen(false);
-    await logout();
-    navigate(ROUTES_PATHS.LOGIN);
-  };
-
-  const toggleDropdown = () => {
-    setIsDropdownOpen(!isDropdownOpen);
-  };
-
   return (
-    <header className="fixed top-0 right-0 left-0 z-50 flex h-15 items-center justify-between border-b border-[#E5E7EB] bg-[#070913] px-6 py-3">
-      <div className="flex items-center justify-start gap-3">
-        <Button
-          className="text-[#ffffff]"
-          onClick={onMenuClick}
-          size="icon"
-          variant="ghost"
-        >
-          <MenuIcon size={24} />
+    <header className={cn(headerRootVariants())}>
+      <div className={cn(headerGroupVariants())}>
+        <Button onClick={onMenuClick} size="icon" variant="ghost">
+          <MenuIcon />
         </Button>
-        <Link
-          className="text-xl font-bold text-[#FFFFFF]"
-          to={ROUTES_PATHS.MAIN}
-        >
+
+        <Link className="text-xl font-bold text-white" to={ROUTES_PATHS.MAIN}>
           Near 0.5
         </Link>
       </div>
+
       {!isLoggedIn ? (
         <Button
-          onClick={handleLogin}
+          onClick={() => navigate(ROUTES_PATHS.LOGIN)}
           rounded="sm"
           size="sm"
           variant="lightGrey"
@@ -85,49 +42,13 @@ export function Header({ onMenuClick }: HeaderProps) {
           로그인
         </Button>
       ) : (
-        <div className="flex items-center gap-3">
-          <Button className="text-[#ffffff]" size="icon" variant="ghost">
-            <SearchIcon size={22} />
+        <div className={cn(headerGroupVariants())}>
+          <Button size="icon" variant="ghost">
+            <SearchIcon />
           </Button>
 
-          <div className="relative">
-            <Button className="text-[#ffffff]" size="icon" variant="ghost">
-              <BellIcon size={22} />
-            </Button>
-            <span className="absolute top-0 right-0 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
-              3
-            </span>
-          </div>
-
-          <div className="relative ml-2" ref={dropdownRef}>
-            <div className="flex items-center gap-1">
-              <Button
-                className="h-10 w-10 rounded-full bg-purple-500 p-0 hover:bg-purple-600"
-                variant="ghost"
-              >
-                <UserIcon className="text-white" size={20} />
-              </Button>
-              <Button
-                className="text-[#ffffff]"
-                onClick={toggleDropdown}
-                size="icon"
-                variant="ghost"
-              >
-                <ChevronDownIcon size={20} />
-              </Button>
-            </div>
-
-            {isDropdownOpen && (
-              <div className="absolute right-0 mt-2 w-40 rounded-md bg-white shadow-lg">
-                <button
-                  className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
-                  onClick={handleLogout}
-                >
-                  로그아웃
-                </button>
-              </div>
-            )}
-          </div>
+          <NotificationDropdown />
+          <UserMenuDropdown />
         </div>
       )}
     </header>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -2,16 +2,17 @@ import { useState } from 'react';
 import { Outlet } from 'react-router';
 
 import { Header, Sidebar, Toaster } from '@/components';
+import { HEADER_HEIGHT } from '@/constants/layout';
 import { cn } from '@/utils';
 
 export default function MainLayout() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-[#1A1F2E]">
-      <Header onMenuClick={() => setIsOpen(!isOpen)} />
+    <div className="min-h-screen">
+      <Header onMenuClick={() => setIsOpen(prev => !prev)} />
 
-      <div className="flex pt-15">
+      <div className="flex" style={{ paddingTop: HEADER_HEIGHT }}>
         <Sidebar isOpen={isOpen} onClose={() => setIsOpen(false)} />
         <main
           className={cn(

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,0 +1,1 @@
+export const HEADER_HEIGHT = 60;

--- a/src/features/notification/api/notification.api.ts
+++ b/src/features/notification/api/notification.api.ts
@@ -1,0 +1,42 @@
+import { api } from '@/api/api';
+
+import type { NotificationItem } from '../types/notification';
+
+type GetNotificationsResponse = {
+  items: {
+    created_at: string;
+    id: number;
+    kind: NotificationItem['kind'];
+    message: string;
+    session_id: number;
+    title: string;
+  }[];
+  total: number;
+};
+
+export async function deleteNotification(
+  notificationId: number,
+): Promise<void> {
+  await api.delete(`/api/v1/notifications/${notificationId}`);
+}
+
+export async function getNotifications(): Promise<NotificationItem[]> {
+  const response = await api.get<GetNotificationsResponse>(
+    '/api/v1/notifications',
+    {
+      params: {
+        limit: 20,
+        status: 'SENT',
+      },
+    },
+  );
+
+  return response.data.items.map(item => ({
+    createdAt: item.created_at,
+    id: item.id,
+    kind: item.kind,
+    message: item.message,
+    sessionId: item.session_id,
+    title: item.title,
+  }));
+}

--- a/src/features/notification/hooks/index.ts
+++ b/src/features/notification/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useDeleteNotificationMutation';
+export * from './useNotificationsQuery';

--- a/src/features/notification/hooks/useDeleteNotificationMutation.ts
+++ b/src/features/notification/hooks/useDeleteNotificationMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteNotification } from '../api/notification.api';
+import { notificationQueryKeys } from '../notificationQueryKeys.ts';
+export function useDeleteNotificationMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteNotification,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: notificationQueryKeys.all,
+      });
+    },
+  });
+}

--- a/src/features/notification/hooks/useNotificationsQuery.ts
+++ b/src/features/notification/hooks/useNotificationsQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getNotifications } from '../api/notification.api';
+import { notificationQueryKeys } from '../notificationQueryKeys.ts';
+
+export function useNotificationsQuery() {
+  return useQuery({
+    queryFn: getNotifications,
+    queryKey: notificationQueryKeys.all,
+  });
+}

--- a/src/features/notification/notificationQueryKeys.ts
+++ b/src/features/notification/notificationQueryKeys.ts
@@ -1,0 +1,3 @@
+export const notificationQueryKeys = {
+  all: ['notifications'] as const,
+};

--- a/src/features/notification/types/notification.ts
+++ b/src/features/notification/types/notification.ts
@@ -1,0 +1,10 @@
+export type NotificationItem = {
+  createdAt: string;
+  id: number;
+  kind: NotificationKind;
+  message: string;
+  sessionId: number;
+  title: string;
+};
+
+export type NotificationKind = 'START';


### PR DESCRIPTION

## 📌 작업 내용

- 헤더 알림 드롭다운 UI 구현
- status=SENT 알림 조회 API 연동
- 알림 클릭 시 DELETE 요청으로 소비 처리
- React Query 기반 조회/삭제 훅 구성
- notification feature 도메인 분리

## 🔗 관련 이슈

- closes #91 

## 📸 스크린샷 (선택)
<img width="1728" height="901" alt="스크린샷 2026-02-06 오전 11 36 19" src="https://github.com/user-attachments/assets/8eaac139-e626-4a12-b771-839f2175749a" />
<img width="1728" height="901" alt="스크린샷 2026-02-06 오전 11 36 32" src="https://github.com/user-attachments/assets/362195f5-b22c-459b-8c49-b0c6427e4e5e" />


## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인