### PR TITLE
feature: 데스크탑 채팅 접기 기능 및 레이아웃 높이 이슈 해결(#94)

### DIFF
--- a/src/components/header/UserMenuDropdown.tsx
+++ b/src/components/header/UserMenuDropdown.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, UserIcon } from 'lucide-react';
+import { UserIcon } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
 import {
@@ -30,7 +30,6 @@ export default function UserMenuDropdown() {
           variant="pink"
         >
           <UserIcon />
-          <ChevronDownIcon />
         </Button>
       </DropdownTrigger>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { MenuIcon, SearchIcon } from 'lucide-react';
+import { MenuIcon } from 'lucide-react';
 import { Link, useNavigate } from 'react-router';
 
 import { Button } from '@/components';
@@ -43,10 +43,6 @@ export function Header({ onMenuClick }: HeaderProps) {
         </Button>
       ) : (
         <div className={cn(headerGroupVariants())}>
-          <Button size="icon" variant="ghost">
-            <SearchIcon />
-          </Button>
-
           <NotificationDropdown />
           <UserMenuDropdown />
         </div>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -9,7 +9,7 @@ export default function MainLayout() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-[#1A1F2E]">
       <Header onMenuClick={() => setIsOpen(prev => !prev)} />
 
       <div className="flex" style={{ paddingTop: HEADER_HEIGHT }}>

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -49,13 +49,16 @@ export const useAuthStore = create<AuthState>((set, get) => {
 
       if (!shouldCheckAuth) {
         setLoggedInStorage(false);
+        set({ isInitialized: true });
         return;
       }
 
       if (!accessToken) {
         await refreshAccessToken();
       }
+      set({ isInitialized: true });
     },
+    isInitialized: false,
     isLoggedIn: () => Boolean(get().accessToken),
     logout: async () => {
       try {

--- a/src/features/auth/types/authTypes.ts
+++ b/src/features/auth/types/authTypes.ts
@@ -2,6 +2,7 @@ export type AuthState = {
   accessToken: null | string;
   clearAccessToken: () => void;
   initializeAuth: () => Promise<void>;
+  isInitialized: boolean;
   isLoggedIn: () => boolean;
   logout: () => Promise<void>;
   refreshAccessToken: () => Promise<null | string>;

--- a/src/features/live/components/ChatMessageItem.tsx
+++ b/src/features/live/components/ChatMessageItem.tsx
@@ -7,7 +7,9 @@ type ChatMessageItemProps = {
 export default function ChatMessageItem({ message }: ChatMessageItemProps) {
   if (message.kind === 'system') {
     return (
-      <li className="py-2 text-center text-xs text-gray-500">{message.text}</li>
+      <li className="py-2 text-center text-xs text-[#BCBCBC]">
+        {message.text}
+      </li>
     );
   }
 
@@ -16,17 +18,14 @@ export default function ChatMessageItem({ message }: ChatMessageItemProps) {
 
   return (
     <li className="flex items-start gap-3">
-      {/* Avatar */}
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-pink-400 to-purple-500 text-xs font-bold">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-[#DC196D] to-[#6F4BFF] text-xs font-bold text-white">
         {initial}
       </div>
 
-      <div className="flex flex-col gap-1">
-        {/* User meta */}
-        <span className="text-xs font-semibold text-gray-300">{userName}</span>
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="text-xs font-semibold text-[#FB64B6]">{userName}</span>
 
-        {/* Message */}
-        <p className="inline-block rounded-md bg-white/5 px-2 py-1 text-sm leading-snug text-gray-100">
+        <p className="inline-block max-w-full rounded-2xl bg-[#1A1F2E] px-4 py-2 text-sm leading-snug wrap-break-word whitespace-normal text-white">
           {message.text}
         </p>
       </div>

--- a/src/features/live/components/ChatPanel.tsx
+++ b/src/features/live/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { SendHorizonalIcon, SmileIcon } from 'lucide-react';
 import { useState } from 'react';
 
-import { Button } from '@/components';
+import { Button, Input } from '@/components';
 import { useChatAutoScroll } from '@/features/live/hooks/useChatAutoScroll';
 import { useLiveChat } from '@/features/live/hooks/useLiveChat';
 
@@ -22,14 +22,17 @@ export default function ChatPanel({
   const [input, setInput] = useState('');
 
   const handleSend = () => {
-    if (!isAuthenticated || !input.trim()) return;
+    if (!isAuthenticated || !input.trim()) {
+      return;
+    }
+
     sendMessage(input.trim());
     setInput('');
   };
 
   return (
-    <section className="flex h-full min-h-0 flex-col rounded-2xl bg-linear-to-b from-[#0B0F1E] to-[#060913]">
-      <header className="shrink-0 border-b border-white/10 px-4 py-3">
+    <section className="flex h-full max-h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-[#282828] bg-[#101828]">
+      <header className="shrink-0 border-b border-[#282828] px-4 py-3">
         <span className="text-sm font-semibold text-white">실시간 채팅</span>
       </header>
 
@@ -47,12 +50,12 @@ export default function ChatPanel({
         <div ref={bottomRef} />
       </ul>
 
-      <div className="shrink-0 border-t border-white/10 px-3 py-2">
-        <div className="flex items-center gap-2 rounded-full bg-[#1A1D2E] px-3 py-2">
-          <SmileIcon className="text-[#9CA3AF]" size={18} />
+      <div className="shrink-0 border-t border-[#282828] px-3 py-2">
+        <div className="flex items-center gap-2 rounded-full bg-[#1A1F2E] px-2 py-2">
+          <SmileIcon className="ml-1 text-[#BCBCBC]" size={18} />
 
-          <input
-            className="min-w-0 flex-1 bg-transparent text-sm text-white placeholder-[#6B7280] outline-none"
+          <Input
+            className="h-9 flex-1 bg-transparent px-3 text-white placeholder:text-[#6B7280]"
             disabled={!isAuthenticated}
             onChange={e => setInput(e.target.value)}
             placeholder={

--- a/src/features/live/components/ChatPlaceholder.tsx
+++ b/src/features/live/components/ChatPlaceholder.tsx
@@ -2,13 +2,18 @@ import { Button } from '@/components';
 
 export default function ChatPlaceholder() {
   return (
-    <div className="flex h-full flex-col rounded border">
-      <div className="flex-1 p-4 text-sm text-gray-400">채팅 영역</div>
+    <div className="flex h-full flex-col rounded-2xl border border-[#282828] bg-[#101828]">
+      <div className="flex flex-1 items-center justify-center px-4 text-sm text-[#BCBCBC]">
+        로그인 후 채팅에 참여할 수 있어요
+      </div>
 
-      <div className="border-t p-3" />
-      <Button className="w-full" size="default" variant="lightGrey">
-        로그인 후 채팅 가능
-      </Button>
+      <div className="h-px w-full bg-[#282828]" />
+
+      <div className="p-3">
+        <Button className="w-full" size="default" variant="pink">
+          로그인 후 채팅 가능
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/features/live/components/LoginRequiredModal.tsx
+++ b/src/features/live/components/LoginRequiredModal.tsx
@@ -20,21 +20,23 @@ export default function LoginRequiredModal({
 }: LoginRequiredModalProps) {
   return (
     <Dialog onOpenChange={onClose} open={isOpen}>
-      <DialogContent>
+      <DialogContent className="rounded-2xl border border-[#282828] bg-[#1A1F2E] p-6">
         <DialogHeader>
-          <DialogTitle>로그인이 필요합니다</DialogTitle>
-          <DialogDescription>
+          <DialogTitle className="text-base font-bold text-white">
+            로그인이 필요합니다
+          </DialogTitle>
+          <DialogDescription className="mt-1 text-sm text-[#BCBCBC]">
             로그인 후 채팅에 참여할 수 있습니다.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="mt-4 flex justify-end gap-2">
+        <div className="mt-6 flex justify-end gap-2">
           <Button onClick={onClose} size="sm" variant="white">
             닫기
           </Button>
 
           {onConfirm && (
-            <Button onClick={onConfirm} size="sm">
+            <Button onClick={onConfirm} size="sm" variant="pink">
               로그인
             </Button>
           )}

--- a/src/features/live/components/MobileStreamLayout.tsx
+++ b/src/features/live/components/MobileStreamLayout.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import type { StreamDetail } from '@/features/live/types/stream';
 
+import { Button } from '@/components';
+
 import ChatPanel from './ChatPanel';
 import StreamInfoSection from './StreamInfoSection';
 import StreamPlayer from './StreamPlayer';
@@ -24,25 +26,26 @@ export default function MobileStreamLayout({
   const isStreamLive = streamDetail?.status === 'LIVE' && playbackUrl != null;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-[#060913]">
-      <div className="aspect-video w-full shrink-0 bg-[#000000]">
+    <div className="flex min-h-0 flex-1 flex-col bg-[#070913]">
+      <div className="aspect-video w-full shrink-0 bg-[#0B0D1A]">
         {isStreamLive ? (
           <StreamPlayer playbackUrl={playbackUrl} />
         ) : (
-          <div className="flex h-full items-center justify-center text-[#9CA3AF]">
+          <div className="flex h-full items-center justify-center text-sm text-[#BCBCBC]">
             방송 준비 중
           </div>
         )}
       </div>
 
       {streamDetail && (
-        <button
-          className="bg-[#0B0F1E] py-2 text-sm text-[#D1D5DB]"
+        <Button
           onClick={() => setIsInfoOpen(true)}
-          type="button"
+          rounded="sm"
+          size="sm"
+          variant="navy"
         >
           방송 정보 보기
-        </button>
+        </Button>
       )}
 
       <div
@@ -56,16 +59,18 @@ export default function MobileStreamLayout({
       </div>
 
       {isInfoOpen && streamDetail && (
-        <div className="fixed inset-0 bg-black/40">
-          <div className="absolute bottom-0 w-full rounded-t-2xl bg-[#0B0F1E] p-4">
+        <div className="fixed inset-0 z-50 bg-black/40">
+          <div className="absolute bottom-0 w-full rounded-t-2xl bg-[#101828] p-4">
             <StreamInfoSection streamDetail={streamDetail} />
-            <button
-              className="mt-4 w-full rounded-md bg-[#1A1D2E] py-2 text-sm text-white"
+
+            <Button
+              className="mt-4 w-full"
               onClick={() => setIsInfoOpen(false)}
-              type="button"
+              size="default"
+              variant="navy"
             >
               닫기
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/src/features/live/components/StreamInfoSection.tsx
+++ b/src/features/live/components/StreamInfoSection.tsx
@@ -9,9 +9,9 @@ type StreamInfoSectionProps = {
 export default function StreamInfoSection({
   streamDetail,
 }: StreamInfoSectionProps) {
-  const STREAM_START_DATE = `${new Date(streamDetail.startAt).toLocaleString()} 시작됨`;
-  const PROFILE_IMG = `${streamDetail.lineup[0].profileImgUrl}`;
-  const ARTIST_NAME = `${streamDetail.lineup[0]?.name || 'Unknown'}`;
+  const streamStartDate = `${new Date(streamDetail.startAt).toLocaleString()} 시작됨`;
+  const profileImg = streamDetail.lineup[0]?.profileImgUrl;
+  const artistName = streamDetail.lineup[0]?.name || 'Unknown';
 
   const tags = [
     streamDetail.category,
@@ -24,42 +24,45 @@ export default function StreamInfoSection({
     <div className="flex flex-col gap-6">
       <div className="rounded-xl bg-[#10131C] p-6">
         <div className="flex items-center gap-2">
-          <span className="rounded bg-[#E7000B] px-2 py-0.5 text-xs font-bold text-[#ffffff]">
+          <span className="rounded bg-[#E7000B] px-2 py-0.5 text-xs font-bold text-white">
             {streamDetail.status}
           </span>
-          <span className="text-xs text-[#C9C9C9]">{STREAM_START_DATE}</span>
+          <span className="text-xs text-[#C9C9C9]">{streamStartDate}</span>
         </div>
 
-        <h1 className="py-2 text-xl font-bold tracking-tight">
+        <h1 className="py-2 text-xl font-bold tracking-tight text-white">
           {streamDetail.concertTitle}
         </h1>
-        <p className="pb-4 text-sm text-[#ffffff]">
-          {streamDetail.sessionName}
-        </p>
+
+        <p className="pb-4 text-sm text-white/80">{streamDetail.sessionName}</p>
 
         <hr className="border-[#4A5565]" />
 
         <div className="flex items-center justify-between py-4">
           <div className="flex items-center gap-3">
-            {PROFILE_IMG ? (
+            {profileImg ? (
               <img
                 alt="Profile"
                 className="h-10 w-10 rounded-full object-cover"
-                src={PROFILE_IMG}
+                src={profileImg}
               />
             ) : (
               <div className="h-10 w-10 rounded-full bg-linear-to-tr from-pink-500 to-violet-500" />
             )}
-            <span className="text-sm font-semibold">{ARTIST_NAME}</span>
+            <span className="text-sm font-semibold text-white">
+              {artistName}
+            </span>
           </div>
-          <Button className="px-6" rounded="full" size="sm" variant="pink">
+
+          <Button rounded="full" size="sm" variant="pink">
             팔로우
           </Button>
         </div>
       </div>
 
       <div className="flex flex-col gap-4 rounded-xl border-2 border-[#4A5565] bg-[#10131C] p-6">
-        <h3 className="text-lg font-bold">방송 정보</h3>
+        <h3 className="text-lg font-bold text-white">방송 정보</h3>
+
         <p className="text-sm leading-relaxed whitespace-pre-line text-[#C7C9D9]">
           {streamDetail.description}
         </p>

--- a/src/features/live/components/StreamPlayer.tsx
+++ b/src/features/live/components/StreamPlayer.tsx
@@ -8,8 +8,8 @@ export default function StreamPlayer({ playbackUrl }: StreamPlayerProps) {
   const { containerRef } = useIVSPlayer({ playbackUrl });
 
   return (
-    <div className="w-full overflow-hidden rounded-xl shadow-lg">
-      <div className="w-full" ref={containerRef} />
+    <div className="relative aspect-video w-full overflow-hidden rounded-xl bg-black">
+      <div className="absolute inset-0 h-full w-full" ref={containerRef} />
     </div>
   );
 }

--- a/src/features/live/hooks/useIVSPlayer.ts
+++ b/src/features/live/hooks/useIVSPlayer.ts
@@ -18,10 +18,13 @@ type UseIVSPlayerProps = {
 export const useIVSPlayer = ({ playbackUrl }: UseIVSPlayerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<null | Player>(null);
-  const PLAYER_CLASSES = ['vjs-big-play-centered', 'vjs-fluid'];
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current) {
+      return;
+    }
+
+    const PLAYER_CLASSES = ['vjs-big-play-centered'];
 
     const videoElement = document.createElement('video-js');
     videoElement.classList.add(...PLAYER_CLASSES);
@@ -31,8 +34,6 @@ export const useIVSPlayer = ({ playbackUrl }: UseIVSPlayerProps) => {
     const videoJsOptions = {
       autoplay: true,
       controls: true,
-      fluid: true,
-      responsive: true,
       sources: [
         {
           src: playbackUrl,
@@ -41,10 +42,7 @@ export const useIVSPlayer = ({ playbackUrl }: UseIVSPlayerProps) => {
       ],
     };
 
-    const player = videojs(videoElement, videoJsOptions, () => {
-      console.log('Player is ready');
-    });
-
+    const player = videojs(videoElement, videoJsOptions);
     playerRef.current = player;
 
     return () => {


### PR DESCRIPTION
## 📌 작업 내용

- 데스크탑 스트리밍 페이지 채팅 접기/펼치기 기능 구현
- 채팅 접힘 상태 localStorage 저장 및 복원 처리
- 채팅 영역 고정 height 적용으로 무한 확장 문제 해결
- 레이아웃 height 충돌로 인한 배경 색상 깨짐 이슈 수정
- Desktop / Tablet / Mobile 반응형 레이아웃 안정화

## 🔗 관련 이슈

- closes #94 

## 📸 스크린샷 (선택)
<img width="1728" height="1117" alt="스크린샷 2026-02-06 오후 2 08 45" src="https://github.com/user-attachments/assets/f946b25a-9bb7-4a0b-a152-1f65d3ef8fc5" />
<img width="1728" height="1117" alt="스크린샷 2026-02-06 오후 2 08 58" src="https://github.com/user-attachments/assets/a3222022-c15d-48fb-a3fd-ecb65062d4d4" />

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
