### PR TITLE
refactor: 팔로우 버튼 로직 연결(#107)

### DIFF
--- a/src/features/live/components/StreamInfoSection.tsx
+++ b/src/features/live/components/StreamInfoSection.tsx
@@ -1,6 +1,11 @@
 import type { StreamDetail } from '@/features/live/types';
 
-import { Button } from '@/components';
+import { Button, FollowButton } from '@/components';
+import {
+  useAddFavoriteArtistMutation,
+  useDeleteFavoriteArtistMutation,
+} from '@/features/main/hooks/useFavoriteArtistMutations';
+import { useFavoriteArtistsQuery } from '@/features/main/hooks/useFavoriteArtistsQuery';
 import { useArtistNavigation } from '@/hooks';
 
 type StreamInfoSectionProps = {
@@ -12,11 +17,19 @@ export default function StreamInfoSection({
 }: StreamInfoSectionProps) {
   const { navigateToArtist } = useArtistNavigation();
 
+  const { data: favoriteArtistsData } = useFavoriteArtistsQuery();
+
+  const { mutate: addFavorite } = useAddFavoriteArtistMutation();
+  const { mutate: deleteFavorite } = useDeleteFavoriteArtistMutation();
+
   const streamStartDate = `${new Date(streamDetail.startAt).toLocaleString()} 시작됨`;
 
   const artistId = streamDetail.lineup[0]?.id;
   const profileImg = streamDetail.lineup[0]?.profileImgUrl;
   const artistName = streamDetail.lineup[0]?.name || 'Unknown';
+
+  const isFollowing =
+    favoriteArtistsData?.items.some(artist => artist.id === artistId) ?? false;
 
   const tags = [
     streamDetail.category,
@@ -24,6 +37,15 @@ export default function StreamInfoSection({
     streamDetail.lineup[0]?.type || 'GroupType',
     streamDetail.status,
   ];
+
+  const handleFollowToggle = (nextIsFollowing: boolean) => {
+    if (!artistId) return;
+    if (nextIsFollowing) {
+      addFavorite({ artistId });
+    } else {
+      deleteFavorite({ artistId });
+    }
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -43,7 +65,7 @@ export default function StreamInfoSection({
 
         <hr className="border-[#4A5565]" />
 
-        <div className="flex items-center justify-between py-4">
+        <div className="flex items-center justify-between pt-4">
           <div className="flex items-center gap-3">
             <Button
               className="flex items-center gap-3 px-0 transition-opacity hover:opacity-80"
@@ -66,9 +88,11 @@ export default function StreamInfoSection({
             </Button>
           </div>
 
-          <Button rounded="full" size="sm" variant="pink">
-            팔로우
-          </Button>
+          <FollowButton
+            initialIsFollowing={isFollowing}
+            key={artistId}
+            onToggle={handleFollowToggle}
+          />
         </div>
       </div>
 

--- a/src/features/main/api/favoriteArtist.ts
+++ b/src/features/main/api/favoriteArtist.ts
@@ -2,9 +2,18 @@ import type {
   AddFavoriteArtistRequest,
   AddFavoriteArtistResponse,
   DeleteFavoriteArtistParams,
+  GetFavoriteArtistsResponse,
 } from '@/features/main/types/favoriteArtist';
 
 import { api } from '@/api/api';
+
+export const getFavoriteArtists =
+  async (): Promise<GetFavoriteArtistsResponse> => {
+    const { data } = await api.get<GetFavoriteArtistsResponse>(
+      'users/me/favorite-artists',
+    );
+    return data;
+  };
 
 export const addFavoriteArtist = async (
   body: AddFavoriteArtistRequest,

--- a/src/features/main/hooks/useFavoriteArtistsQuery.ts
+++ b/src/features/main/hooks/useFavoriteArtistsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type { GetFavoriteArtistsResponse } from '@/features/main/types/favoriteArtist';
+
+import { getFavoriteArtists } from '@/features/main/api/favoriteArtist';
+
+export const useFavoriteArtistsQuery = () =>
+  useQuery<GetFavoriteArtistsResponse, Error>({
+    queryFn: getFavoriteArtists,
+    queryKey: ['favoriteArtists'],
+    staleTime: 1000 * 60,
+  });

--- a/src/features/main/types/favoriteArtist.ts
+++ b/src/features/main/types/favoriteArtist.ts
@@ -13,3 +13,19 @@ export type AddFavoriteArtistResponse = {
 export type DeleteFavoriteArtistParams = {
   artistId: number;
 };
+
+export type FavoriteArtistItem = {
+  agency: string;
+  categoryType: string;
+  createdAt: string;
+  groupType: string;
+  id: number;
+  memberCount: number;
+  name: string;
+  profileImage: null | string;
+};
+
+export type GetFavoriteArtistsResponse = {
+  items: FavoriteArtistItem[];
+  total: number;
+};

--- a/src/pages/ArtistListPage.tsx
+++ b/src/pages/ArtistListPage.tsx
@@ -3,6 +3,11 @@ import type { Artist } from '@/features/main/types/artist';
 import { FollowButton } from '@/components';
 import HeroBanner from '@/features/main/components/HeroBanner';
 import { useArtistListQuery } from '@/features/main/hooks/useArtistListQuery';
+import {
+  useAddFavoriteArtistMutation,
+  useDeleteFavoriteArtistMutation,
+} from '@/features/main/hooks/useFavoriteArtistMutations';
+import { useFavoriteArtistsQuery } from '@/features/main/hooks/useFavoriteArtistsQuery';
 
 const MOCK_ARTISTS: Artist[] = [
   {
@@ -30,6 +35,11 @@ const MOCK_ARTISTS: Artist[] = [
 
 export default function ArtistListPage() {
   const { data, isError, isSuccess } = useArtistListQuery();
+
+  const { data: favoriteArtistsData } = useFavoriteArtistsQuery();
+
+  const { mutate: addFavorite } = useAddFavoriteArtistMutation();
+  const { mutate: deleteFavorite } = useDeleteFavoriteArtistMutation();
 
   const rawArtists: Artist[] = data?.items ?? [];
   const useMock = isError || !isSuccess || rawArtists.length === 0;
@@ -68,45 +78,65 @@ export default function ArtistListPage() {
           </p>
         ) : (
           <section className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {artists.map(artist => (
-              <article
-                className="flex h-full flex-col rounded-3xl bg-[#10131C] p-5 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]"
-                key={artist.id}
-              >
-                <div className="h-66.5 w-full overflow-hidden rounded-2xl bg-gray-700">
-                  {artist.profileImage ? (
-                    <img
-                      alt={artist.name}
-                      className="h-full w-full object-cover"
-                      src={artist.profileImage}
-                    />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center text-sm text-gray-400">
-                      No Image
-                    </div>
-                  )}
-                </div>
+            {artists.map(artist => {
+              // 1. [핵심] 반복문 안에서 '현재 아티스트'가 내 목록에 있는지 확인
+              const isFollowing =
+                favoriteArtistsData?.items.some(fav => fav.id === artist.id) ??
+                false;
 
-                <div className="mt-4 flex flex-1 flex-col">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <h3 className="text-base font-bold tracking-[-0.04em] lg:text-lg">
-                        {artist.name}
-                      </h3>
-                      <p className="text-xs text-[#D9D9D9]">{artist.agency}</p>
-                      <p className="text-xs text-[#D9D9D9]">
-                        {artist.followerCount} 팔로워
-                      </p>
-                    </div>
-
-                    <FollowButton
-                      className="mt-1 shrink-0"
-                      initialIsFollowing={false}
-                    />
+              return (
+                <article
+                  className="flex h-full flex-col rounded-3xl bg-[#10131C] p-5 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]"
+                  key={artist.id}
+                >
+                  <div className="h-66.5 w-full overflow-hidden rounded-2xl bg-gray-700">
+                    {artist.profileImage ? (
+                      <img
+                        alt={artist.name}
+                        className="h-full w-full object-cover"
+                        src={artist.profileImage}
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-sm text-gray-400">
+                        No Image
+                      </div>
+                    )}
                   </div>
-                </div>
-              </article>
-            ))}
+
+                  <div className="mt-4 flex flex-1 flex-col">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <h3 className="text-base font-bold tracking-[-0.04em] lg:text-lg">
+                          {artist.name}
+                        </h3>
+                        <p className="text-xs text-[#D9D9D9]">
+                          {artist.agency}
+                        </p>
+                        <p className="text-xs text-[#D9D9D9]">
+                          {artist.followerCount} 팔로워
+                        </p>
+                      </div>
+
+                      {/* 2. [핵심] 버튼 연결 */}
+                      <FollowButton
+                        className="mt-1 shrink-0"
+                        // 위에서 계산한 값 넣어주기
+                        initialIsFollowing={isFollowing}
+                        // 토글 될 때 실행할 로직을 인라인으로 작성
+                        onToggle={nextIsFollowing => {
+                          if (nextIsFollowing) {
+                            // 여기서는 artist.id 접근 가능!
+                            addFavorite({ artistId: artist.id });
+                          } else {
+                            deleteFavorite({ artistId: artist.id });
+                          }
+                        }}
+                      />
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
           </section>
         )}
       </main>


### PR DESCRIPTION
## 📌 작업 내용

- 팔로우 목록 조회 api 및 훅 추가
- 스트리밍 페이지 및 아티스트 리스트 페이지 팔로우 버튼 로직 연결

## 🔗 관련 이슈

- closes #107

## 📸 스크린샷 (선택)
<img width="1374" height="906" alt="image" src="https://github.com/user-attachments/assets/92f33f6b-b4fa-44a6-951b-2228c5dfab1d" />


## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
