### PR TITLE
fix: modal, dropdown 공통 컴포넌트 다크 테마 색상 수정(#112)

### DIFF
--- a/src/components/common/dropdown/DropdownContent.tsx
+++ b/src/components/common/dropdown/DropdownContent.tsx
@@ -20,7 +20,15 @@ export default function DropdownContent({
       <DropdownMenu.Content
         align={align}
         className={cn(
-          'z-50 min-w-40 rounded-md border bg-white p-1 shadow-md',
+          [
+            'z-50 min-w-40 p-1',
+            'rounded-lg',
+
+            'bg-[#1A1F2E] text-white',
+            'border border-[#2A2F3E]',
+
+            'shadow-xl shadow-black/40',
+          ],
           className,
         )}
         sideOffset={sideOffset}

--- a/src/components/common/dropdown/DropdownItem.tsx
+++ b/src/components/common/dropdown/DropdownItem.tsx
@@ -17,12 +17,19 @@ export default function DropdownItem({
 }: DropdownItemProps) {
   return (
     <DropdownMenu.Item
-      className={cn(
-        'flex cursor-pointer items-center rounded px-3 py-2 text-sm outline-none select-none',
-        'focus:bg-gray-100',
-        isDisabled && 'cursor-not-allowed opacity-50',
-        isDanger && 'text-red-600 focus:bg-red-50',
-      )}
+      className={cn([
+        'flex items-center rounded px-3 py-2 text-sm outline-none select-none',
+        'cursor-pointer text-white',
+
+        'focus:bg-[#2A2F3E] data-highlighted:bg-[#2A2F3E]',
+
+        'data-disabled:cursor-not-allowed data-disabled:opacity-50',
+
+        isDanger && [
+          'text-red-400',
+          'focus:bg-red-900/30 data-highlighted:bg-red-900/30',
+        ],
+      ])}
       disabled={isDisabled}
       onSelect={onSelect}
     >

--- a/src/components/common/dropdown/DropdownSeparator.tsx
+++ b/src/components/common/dropdown/DropdownSeparator.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 
 export default function DropdownSeparator() {
-  return <DropdownMenu.Separator className="my-1 h-px bg-gray-200" />;
+  return <DropdownMenu.Separator className="my-1 h-px bg-[#2A2F3E]" />;
 }

--- a/src/components/common/modal/ModalContent.tsx
+++ b/src/components/common/modal/ModalContent.tsx
@@ -11,7 +11,21 @@ export default function ModalContent({
   className,
 }: ModalContentProps) {
   return (
-    <DialogContent className={cn('max-w-lg rounded-lg p-6', className)}>
+    <DialogContent
+      className={cn(
+        [
+          'max-w-lg p-6',
+
+          'rounded-xl',
+
+          'bg-[#1A1F2E] text-white',
+          'border border-[#2A2F3E]',
+
+          'shadow-xl shadow-black/40',
+        ],
+        className,
+      )}
+    >
       {children}
     </DialogContent>
   );

--- a/src/components/common/modal/ModalDescription.tsx
+++ b/src/components/common/modal/ModalDescription.tsx
@@ -1,12 +1,17 @@
 import { DialogDescription } from '@/components';
+import { cn } from '@/utils';
 
 type ModalDescriptionProps = {
   children: React.ReactNode;
+  className?: string;
 };
 
-export default function ModalDescription({ children }: ModalDescriptionProps) {
+export default function ModalDescription({
+  children,
+  className,
+}: ModalDescriptionProps) {
   return (
-    <DialogDescription className="text-sm text-gray-500">
+    <DialogDescription className={cn('text-sm text-[#9CA3AF]', className)}>
       {children}
     </DialogDescription>
   );

--- a/src/components/common/modal/ModalHeader.tsx
+++ b/src/components/common/modal/ModalHeader.tsx
@@ -6,5 +6,9 @@ type ModalHeaderProps = {
 };
 
 export default function ModalHeader({ children, className }: ModalHeaderProps) {
-  return <div className={cn('mb-4 space-y-1', className)}>{children}</div>;
+  return (
+    <div className={cn(['mb-4 space-y-1', 'text-white'], className)}>
+      {children}
+    </div>
+  );
 }

--- a/src/components/common/modal/ModalTitle.tsx
+++ b/src/components/common/modal/ModalTitle.tsx
@@ -1,11 +1,15 @@
 import { DialogTitle } from '@/components';
+import { cn } from '@/utils';
 
 type ModalTitleProps = {
   children: React.ReactNode;
+  className?: string;
 };
 
-export default function ModalTitle({ children }: ModalTitleProps) {
+export default function ModalTitle({ children, className }: ModalTitleProps) {
   return (
-    <DialogTitle className="text-lg font-semibold">{children}</DialogTitle>
+    <DialogTitle className={cn('text-lg font-semibold text-white', className)}>
+      {children}
+    </DialogTitle>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용

- modal 컴포넌트 배경, 텍스트, description 색상 정합성 수정
- dropdown 메뉴 배경, 아이템 hover/focus, divider 색상 다크 테마 기준으로 변경
- 라이트 테마 전용 gray/bg-white 스타일 제거
## 🔗 관련 이슈

- closes #112 

## 📸 스크린샷 (선택)
<img width="453" height="251" alt="스크린샷 2026-02-08 오후 3 21 00" src="https://github.com/user-attachments/assets/d10d858a-a962-48eb-bc9d-7238eb6a3221" />

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
