### PR TITLE
fix: 메인페이지 반응형 및 아티스트/콘서트 카드 최소 너비 개선(#125)

### DIFF
--- a/src/features/main/components/ArtistSection.tsx
+++ b/src/features/main/components/ArtistSection.tsx
@@ -63,13 +63,13 @@ export default function ArtistSection({ title }: ArtistSectionProps) {
             추천 아티스트가 없습니다.
           </div>
         ) : (
-          <div className="flex gap-4 pb-4">
+          <div className="flex flex-wrap gap-4 pb-4">
             {list.map(({ id, name, profileImage }) => {
               const showRealImage = hasRealImage(profileImage);
 
               return (
                 <article
-                  className="flex w-34.5 flex-col items-center justify-center"
+                  className="flex min-w-30 flex-col items-center justify-center"
                   key={id}
                 >
                   <div className="h-16 w-16 overflow-hidden rounded-full border-2 border-transparent transition-colors hover:border-[#DC196D]">

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -18,7 +18,7 @@ export default function MainPage() {
     list.find(concert => concert.id === HERO_CONCERT_ID) ?? undefined;
 
   return (
-    <div className="min-h-screen bg-[#1A1F2E]">
+    <div className="min-h-screen overflow-x-hidden bg-[#1A1F2E]">
       <HeroBanner concert={heroConcert} />
       <UpcomingStreamingSection title="예정된 콘서트" />
       <OngoingStreamingSection title="진행중인 라이브 콘서트" />


### PR DESCRIPTION
## 📌 작업 내용

-  메인페이지 반응형 완성

## 🔗 관련 이슈

- closes #125

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
